### PR TITLE
feat: add reusable loading spinner components (#10)

### DIFF
--- a/src/components/common/ButtonSpinner.jsx
+++ b/src/components/common/ButtonSpinner.jsx
@@ -1,0 +1,7 @@
+import Spinner from './Spinner';
+
+const ButtonSpinner = ({ className = '' }) => {
+  return <Spinner className={`text-current ${className}`} size="sm" />;
+};
+
+export default ButtonSpinner;

--- a/src/components/common/FullPageLoader.jsx
+++ b/src/components/common/FullPageLoader.jsx
@@ -1,0 +1,14 @@
+import Spinner from './Spinner';
+
+const FullPageLoader = ({ className = '' }) => {
+  return (
+    <div
+      aria-busy="true"
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-[1px] ${className}`}
+    >
+      <Spinner className="text-white" size="lg" />
+    </div>
+  );
+};
+
+export default FullPageLoader;

--- a/src/components/common/Spinner.jsx
+++ b/src/components/common/Spinner.jsx
@@ -1,0 +1,19 @@
+const sizeClassMap = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-6 w-6 border-2',
+  lg: 'h-10 w-10 border-4',
+};
+
+const Spinner = ({ size = 'md', className = '' }) => {
+  const spinnerSizeClass = sizeClassMap[size] || sizeClassMap.md;
+
+  return (
+    <span
+      aria-label="Loading"
+      className={`inline-block animate-spin rounded-full border-solid border-current border-t-transparent ${spinnerSizeClass} ${className}`}
+      role="status"
+    />
+  );
+};
+
+export default Spinner;


### PR DESCRIPTION
## Setup Loading Spinner Component #10

<img width="630" height="329" alt="Screenshot from 2026-03-02 11-14-23" src="https://github.com/user-attachments/assets/4bac5f12-f1d6-446d-a1a9-09b4d63528c3" />

### Summary
Added reusable loading spinner components for different UI contexts with full Tailwind CSS animation and accessibility support.

### Changes
- **src/components/common/Spinner.jsx**: Base reusable spinner component with size variants (sm, md, lg)
- **src/components/common/FullPageLoader.jsx**: Full-page overlay loader for global loading states
- **src/components/common/ButtonSpinner.jsx**: Compact spinner for use inside loading buttons

### Implementation Details
✅ Spinner component supports size prop: `sm` (h-4 w-4), `md` (h-6 w-6), `lg` (h-10 w-10)
✅ Uses Tailwind's `animate-spin` utility for smooth spinning animation
✅ Accessibility features included:
  - `aria-label="Loading"` on Spinner
  - `role="status"` on Spinner
  - `aria-busy="true"` on FullPageLoader
✅ FullPageLoader creates fixed overlay spanning entire viewport with semi-transparent backdrop
✅ Color-agnostic design - accepts className prop for custom color variants

Closes #10 
### Testing
The following CI checks passed locally:
- `npm ci` (clean install)
- `npm run lint` (ESLint validation)
- `npm test` (test suite)
- `npm run build` (production build)
