### PR TITLE
feat: add Navbar, Footer, and MainLayout with responsive routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1804,6 +1805,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1851,6 +1853,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2013,6 +2016,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2179,7 +2183,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2376,6 +2381,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3556,6 +3562,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3583,6 +3590,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3650,6 +3658,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3659,6 +3668,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3671,6 +3681,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3713,6 +3724,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3783,7 +3795,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -3950,7 +3963,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -4083,6 +4097,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4216,6 +4231,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,0 +1,226 @@
+import { Link } from 'react-router-dom';
+
+const PLATFORM_LINKS = [
+  { label: 'How it works', to: '/how-it-works' },
+  { label: 'Projects',     to: '/explore'      },
+  { label: 'About',        to: '/about'         },
+];
+
+const LEGAL_LINKS = [
+  { label: 'Privacy', to: '/privacy' },
+  { label: 'Terms',   to: '/terms'   },
+  { label: 'Contact', to: '/contact' },
+];
+
+/* Simple inline SVGs — no external icon library required */
+const TwitterIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L2.012 2.25h6.962l4.265 5.636 5.005-5.636Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/>
+  </svg>
+);
+
+const DiscordIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true">
+    <path d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.175 13.175 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028ZM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38Zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38Z"/>
+  </svg>
+);
+
+const GitHubIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden="true">
+    <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z"/>
+  </svg>
+);
+
+export default function Footer() {
+  return (
+    <>
+      <style>{`
+        .sft-root {
+          background: #fff;
+          border-top: 1px solid #e8ecf0;
+          font-family: 'Poppins', sans-serif;
+          color: #475569;
+          font-size: .875rem;
+        }
+        .sft-top {
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 3rem 1.5rem 2.5rem;
+          display: grid;
+          grid-template-columns: 1.6fr 1fr 1fr 1fr;
+          gap: 2.5rem;
+        }
+        /* Brand column */
+        .sft-brand {
+          display: flex;
+          flex-direction: column;
+          gap: .75rem;
+        }
+        .sft-logo {
+          display: flex;
+          align-items: center;
+          gap: .6rem;
+          text-decoration: none;
+        }
+        .sft-logo-icon {
+          width: 32px;
+          height: 32px;
+          border-radius: 7px;
+          background: #1e3a6e;
+          color: #fff;
+          font-size: .85rem;
+          font-weight: 700;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .sft-logo-text {
+          font-size: 1rem;
+          font-weight: 700;
+          color: #0f172a;
+          letter-spacing: -.3px;
+        }
+        .sft-tagline {
+          color: #64748b;
+          font-size: .82rem;
+          line-height: 1.55;
+          max-width: 220px;
+        }
+
+        /* Link columns */
+        .sft-col h4 {
+          font-size: .78rem;
+          font-weight: 600;
+          color: #0f172a;
+          text-transform: uppercase;
+          letter-spacing: .07em;
+          margin-bottom: 1rem;
+        }
+        .sft-col ul {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: .55rem;
+        }
+        .sft-col a {
+          color: #64748b;
+          text-decoration: none;
+          transition: color .15s;
+        }
+        .sft-col a:hover { color: #1e3a6e; }
+
+        /* Social icons */
+        .sft-socials {
+          display: flex;
+          gap: .6rem;
+          margin-top: .25rem;
+        }
+        .sft-social-btn {
+          width: 34px;
+          height: 34px;
+          border-radius: 8px;
+          border: 1px solid #e8ecf0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: #64748b;
+          text-decoration: none;
+          transition: background .15s, color .15s, border-color .15s;
+        }
+        .sft-social-btn:hover {
+          background: #1e3a6e;
+          color: #fff;
+          border-color: #1e3a6e;
+        }
+
+        /* Bottom bar */
+        .sft-bottom {
+          border-top: 1px solid #e8ecf0;
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 1.1rem 1.5rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: #94a3b8;
+          font-size: .8rem;
+          text-align: center;
+        }
+
+        /* Responsive */
+        @media (max-width: 900px) {
+          .sft-top {
+            grid-template-columns: 1fr 1fr;
+          }
+          .sft-brand { grid-column: 1 / -1; }
+        }
+        @media (max-width: 540px) {
+          .sft-top {
+            grid-template-columns: 1fr;
+            padding: 2rem 1.25rem;
+            gap: 1.75rem;
+          }
+          .sft-brand { grid-column: auto; }
+        }
+      `}</style>
+
+      <footer className="sft-root" role="contentinfo">
+        <div className="sft-top">
+          {/* Brand */}
+          <div className="sft-brand">
+            <Link to="/" className="sft-logo">
+              <span className="sft-logo-icon">S</span>
+              <span className="sft-logo-text">StellarAid</span>
+            </Link>
+            <p className="sft-tagline">Transparent charitable giving on blockchain</p>
+          </div>
+
+          {/* Platform */}
+          <div className="sft-col">
+            <h4>Platform</h4>
+            <ul>
+              {PLATFORM_LINKS.map(({ label, to }) => (
+                <li key={to}><Link to={to}>{label}</Link></li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Legal */}
+          <div className="sft-col">
+            <h4>Legal</h4>
+            <ul>
+              {LEGAL_LINKS.map(({ label, to }) => (
+                <li key={to}><Link to={to}>{label}</Link></li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Connect */}
+          <div className="sft-col">
+            <h4>Connect</h4>
+            <div className="sft-socials">
+              <a href="https://twitter.com" target="_blank" rel="noopener noreferrer"
+                 className="sft-social-btn" aria-label="Twitter / X">
+                <TwitterIcon />
+              </a>
+              <a href="https://discord.com" target="_blank" rel="noopener noreferrer"
+                 className="sft-social-btn" aria-label="Discord">
+                <DiscordIcon />
+              </a>
+              <a href="https://github.com" target="_blank" rel="noopener noreferrer"
+                 className="sft-social-btn" aria-label="GitHub">
+                <GitHubIcon />
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div className="sft-bottom">
+          © {new Date().getFullYear()} StellarAid. All rights reserved.
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,9 +1,33 @@
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
+import Navbar from './Navbar';
+import Footer from './Footer';
 
-const MainLayout = () => {
+/**
+ * MainLayout
+ * Wraps every public page with the sticky Navbar and Footer.
+ * Usage in AppRouter.jsx:
+ *
+ *   <Route element={<MainLayout />}>
+ *     <Route path="/"        element={<Home />} />
+ *     <Route path="/explore" element={<Explore />} />
+ *     …
+ *   </Route>
+ */
+export default function MainLayout() {
   return (
-    <div>
+    <>
+      <style>{`
+        .ml-root {
+          display: flex;
+          flex-direction: column;
+          min-height: 100vh;
+        }
+        .ml-main {
+          flex: 1;
+        }
+      `}</style>
+
       <Toaster
         position="top-right"
         toastOptions={{
@@ -13,59 +37,33 @@ const MainLayout = () => {
             background: '#ffffff',
             color: '#0F172A',
             borderRadius: '8px',
+            fontFamily: "'Poppins', sans-serif",
+            fontSize: '.875rem',
             boxShadow:
-              '0 10px 15px -3px rgba(15,23,42,0.1), 0 4px 6px -4px rgba(15,23,42,0.1)',
+              '0 10px 15px -3px rgba(15,23,42,.1), 0 4px 6px -4px rgba(15,23,42,.1)',
           },
           success: {
-            iconTheme: {
-              primary: '#10B981',
-              secondary: '#ffffff',
-            },
-            style: {
-              borderColor: '#10B981',
-            },
+            iconTheme: { primary: '#10B981', secondary: '#ffffff' },
+            style: { borderColor: '#10B981' },
           },
           error: {
-            iconTheme: {
-              primary: '#EF4444',
-              secondary: '#ffffff',
-            },
-            style: {
-              borderColor: '#EF4444',
-            },
+            iconTheme: { primary: '#EF4444', secondary: '#ffffff' },
+            style: { borderColor: '#EF4444' },
           },
           loading: {
-            iconTheme: {
-              primary: '#6366F1',
-              secondary: '#ffffff',
-            },
-            style: {
-              borderColor: '#6366F1',
-            },
+            iconTheme: { primary: '#6366F1', secondary: '#ffffff' },
+            style: { borderColor: '#6366F1' },
           },
         }}
       />
-      <header>
-        <nav style={{ display: 'flex', gap: '1rem', padding: '1rem', background: '#f0f0f0' }}>
-          <Link to="/">Home</Link>
-          <Link to="/explore">Explore</Link>
-          <Link to="/create">Create Campaign</Link>
-          <Link to="/dashboard">Dashboard</Link>
-          <Link to="/admin">Admin</Link>
-          <Link to="/login">Login</Link>
-          <Link to="/register">Register</Link>
-        </nav>
-      </header>
-      
-      <main style={{ padding: '2 rem' }}>
-        <Outlet />
-      </main>
 
-      <footer style={{ padding: '1rem', textAlign: 'center', marginTop: 'auto', background: '#f0f0f0' }}>
-        <p>© {new Date().getFullYear()} StellarAid. All rights reserved.</p>
-      </footer>
-    </div>
+      <div className="ml-root">
+        <Navbar />
+        <main className="ml-main">
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </>
   );
-};
-
-export default MainLayout;
+}

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -1,0 +1,419 @@
+import { useState, useRef, useEffect } from 'react';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
+
+// ─── Replace with your real auth hook / context ───────────────────────────────
+// e.g.  import { useAuth } from '../../contexts/AuthContext';
+const useAuth = () => ({
+  user: null,          // set to a user object when logged in, e.g. { name: 'Alice', avatarUrl: null }
+  logout: () => {},
+});
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NAV_LINKS = [
+  { label: 'How it works', to: '/how-it-works' },
+  { label: 'Projects',     to: '/explore'      },
+  { label: 'About',        to: '/about'         },
+];
+
+function initials(name = '') {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function Navbar() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const [menuOpen,   setMenuOpen]   = useState(false);
+  const [avatarOpen, setAvatarOpen] = useState(false);
+  const avatarRef = useRef(null);
+
+  /* close avatar dropdown on outside click */
+  useEffect(() => {
+    function handler(e) {
+      if (avatarRef.current && !avatarRef.current.contains(e.target)) {
+        setAvatarOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  /* close mobile menu on route change */
+  const handleNavClick = () => setMenuOpen(false);
+
+  const handleLogout = () => {
+    setAvatarOpen(false);
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <>
+      <style>{`
+        /* ── Navbar ─────────────────────────────────────────────── */
+        .sna-root {
+          position: sticky;
+          top: 0;
+          z-index: 100;
+          background: #ffffff;
+          border-bottom: 1px solid #e8ecf0;
+          box-shadow: 0 1px 4px rgba(15,23,42,.06);
+          font-family: 'Poppins', sans-serif;
+        }
+        .sna-inner {
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 0 1.5rem;
+          height: 64px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 1rem;
+        }
+
+        /* Logo */
+        .sna-logo {
+          display: flex;
+          align-items: center;
+          gap: .6rem;
+          text-decoration: none;
+          flex-shrink: 0;
+        }
+        .sna-logo-icon {
+          width: 34px;
+          height: 34px;
+          border-radius: 8px;
+          background: #1e3a6e;
+          color: #fff;
+          font-size: .9rem;
+          font-weight: 700;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          letter-spacing: -.5px;
+        }
+        .sna-logo-text {
+          font-size: 1.05rem;
+          font-weight: 700;
+          color: #0f172a;
+          letter-spacing: -.3px;
+        }
+
+        /* Desktop nav links */
+        .sna-links {
+          display: flex;
+          align-items: center;
+          gap: .25rem;
+          list-style: none;
+          margin: 0;
+          padding: 0;
+        }
+        .sna-links a {
+          padding: .45rem .85rem;
+          border-radius: 6px;
+          font-size: .875rem;
+          font-weight: 500;
+          color: #475569;
+          text-decoration: none;
+          transition: background .15s, color .15s;
+          white-space: nowrap;
+        }
+        .sna-links a:hover,
+        .sna-links a.active {
+          background: #f1f5f9;
+          color: #0f172a;
+        }
+
+        /* Auth buttons */
+        .sna-auth {
+          display: flex;
+          align-items: center;
+          gap: .6rem;
+          flex-shrink: 0;
+        }
+        .sna-btn-ghost {
+          padding: .45rem 1rem;
+          border-radius: 6px;
+          font-size: .875rem;
+          font-weight: 500;
+          color: #0f172a;
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          text-decoration: none;
+          transition: background .15s;
+          white-space: nowrap;
+        }
+        .sna-btn-ghost:hover { background: #f1f5f9; }
+        .sna-btn-primary {
+          padding: .45rem 1.15rem;
+          border-radius: 6px;
+          font-size: .875rem;
+          font-weight: 600;
+          color: #fff;
+          background: #1e3a6e;
+          border: none;
+          cursor: pointer;
+          text-decoration: none;
+          transition: background .15s, transform .1s;
+          white-space: nowrap;
+        }
+        .sna-btn-primary:hover { background: #162d56; transform: translateY(-1px); }
+
+        /* Avatar dropdown */
+        .sna-avatar-wrap {
+          position: relative;
+        }
+        .sna-avatar-btn {
+          width: 36px;
+          height: 36px;
+          border-radius: 50%;
+          background: #1e3a6e;
+          color: #fff;
+          font-size: .8rem;
+          font-weight: 700;
+          border: 2px solid #e8ecf0;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          overflow: hidden;
+          transition: border-color .15s;
+        }
+        .sna-avatar-btn:hover { border-color: #1e3a6e; }
+        .sna-avatar-btn img { width: 100%; height: 100%; object-fit: cover; }
+        .sna-dropdown {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: 180px;
+          background: #fff;
+          border: 1px solid #e8ecf0;
+          border-radius: 10px;
+          box-shadow: 0 8px 24px rgba(15,23,42,.12);
+          padding: .4rem;
+          animation: dropIn .15s ease;
+        }
+        @keyframes dropIn {
+          from { opacity: 0; transform: translateY(-6px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .sna-dropdown-name {
+          padding: .5rem .75rem .35rem;
+          font-size: .75rem;
+          font-weight: 600;
+          color: #94a3b8;
+          text-transform: uppercase;
+          letter-spacing: .05em;
+        }
+        .sna-dropdown a,
+        .sna-dropdown button.sna-dd-item {
+          display: block;
+          width: 100%;
+          text-align: left;
+          padding: .5rem .75rem;
+          border-radius: 6px;
+          font-size: .875rem;
+          color: #334155;
+          text-decoration: none;
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          transition: background .12s;
+        }
+        .sna-dropdown a:hover,
+        .sna-dropdown button.sna-dd-item:hover { background: #f1f5f9; }
+        .sna-dropdown .sna-dd-divider {
+          height: 1px;
+          background: #e8ecf0;
+          margin: .3rem 0;
+        }
+        .sna-dd-logout { color: #ef4444 !important; }
+
+        /* Hamburger */
+        .sna-hamburger {
+          display: none;
+          flex-direction: column;
+          gap: 5px;
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          padding: .4rem;
+          border-radius: 6px;
+          transition: background .15s;
+        }
+        .sna-hamburger:hover { background: #f1f5f9; }
+        .sna-hamburger span {
+          display: block;
+          width: 22px;
+          height: 2px;
+          background: #0f172a;
+          border-radius: 2px;
+          transition: transform .25s, opacity .25s;
+          transform-origin: center;
+        }
+        .sna-hamburger.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+        .sna-hamburger.open span:nth-child(2) { opacity: 0; }
+        .sna-hamburger.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+        /* Mobile drawer */
+        .sna-mobile {
+          display: none;
+          flex-direction: column;
+          background: #fff;
+          border-top: 1px solid #e8ecf0;
+          padding: .75rem 1.5rem 1.25rem;
+          gap: .25rem;
+          animation: slideDown .2s ease;
+        }
+        @keyframes slideDown {
+          from { opacity: 0; transform: translateY(-8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .sna-mobile a {
+          padding: .6rem .75rem;
+          border-radius: 6px;
+          font-size: .9rem;
+          font-weight: 500;
+          color: #334155;
+          text-decoration: none;
+          transition: background .12s;
+        }
+        .sna-mobile a:hover,
+        .sna-mobile a.active { background: #f1f5f9; color: #0f172a; }
+        .sna-mobile-divider {
+          height: 1px;
+          background: #e8ecf0;
+          margin: .5rem 0;
+        }
+        .sna-mobile-auth {
+          display: flex;
+          flex-direction: column;
+          gap: .4rem;
+          margin-top: .25rem;
+        }
+        .sna-mobile-auth .sna-btn-primary,
+        .sna-mobile-auth .sna-btn-ghost {
+          display: block;
+          text-align: center;
+          width: 100%;
+          padding: .65rem 1rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+          .sna-links  { display: none; }
+          .sna-auth   { display: none; }
+          .sna-hamburger { display: flex; }
+          .sna-mobile.open { display: flex; }
+        }
+      `}</style>
+
+      <nav className="sna-root" role="navigation" aria-label="Main navigation">
+        <div className="sna-inner">
+          {/* Logo */}
+          <Link to="/" className="sna-logo" onClick={handleNavClick}>
+            <span className="sna-logo-icon">S</span>
+            <span className="sna-logo-text">StellarAid</span>
+          </Link>
+
+          {/* Desktop nav */}
+          <ul className="sna-links" role="list">
+            {NAV_LINKS.map(({ label, to }) => (
+              <li key={to}>
+                <NavLink to={to} className={({ isActive }) => isActive ? 'active' : ''}>
+                  {label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+
+          {/* Desktop auth */}
+          <div className="sna-auth">
+            {user ? (
+              <div className="sna-avatar-wrap" ref={avatarRef}>
+                <button
+                  className="sna-avatar-btn"
+                  onClick={() => setAvatarOpen((v) => !v)}
+                  aria-label="User menu"
+                  aria-expanded={avatarOpen}
+                >
+                  {user.avatarUrl
+                    ? <img src={user.avatarUrl} alt={user.name} />
+                    : initials(user.name)
+                  }
+                </button>
+                {avatarOpen && (
+                  <div className="sna-dropdown" role="menu">
+                    <div className="sna-dropdown-name">{user.name}</div>
+                    <div className="sna-dd-divider" />
+                    <Link to="/dashboard" role="menuitem" onClick={() => setAvatarOpen(false)}>Dashboard</Link>
+                    <Link to="/profile"   role="menuitem" onClick={() => setAvatarOpen(false)}>Profile</Link>
+                    <Link to="/settings"  role="menuitem" onClick={() => setAvatarOpen(false)}>Settings</Link>
+                    <div className="sna-dd-divider" />
+                    <button className="sna-dd-item sna-dd-logout" role="menuitem" onClick={handleLogout}>
+                      Sign out
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
+                <Link to="/login"    className="sna-btn-ghost">Sign In</Link>
+                <Link to="/register" className="sna-btn-primary">Get Started</Link>
+              </>
+            )}
+          </div>
+
+          {/* Hamburger */}
+          <button
+            className={`sna-hamburger${menuOpen ? ' open' : ''}`}
+            onClick={() => setMenuOpen((v) => !v)}
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={menuOpen}
+          >
+            <span /><span /><span />
+          </button>
+        </div>
+
+        {/* Mobile drawer */}
+        <div className={`sna-mobile${menuOpen ? ' open' : ''}`} aria-hidden={!menuOpen}>
+          {NAV_LINKS.map(({ label, to }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) => isActive ? 'active' : ''}
+              onClick={handleNavClick}
+            >
+              {label}
+            </NavLink>
+          ))}
+
+          <div className="sna-mobile-divider" />
+
+          {user ? (
+            <>
+              <Link to="/dashboard" onClick={handleNavClick}>Dashboard</Link>
+              <Link to="/profile"   onClick={handleNavClick}>Profile</Link>
+              <Link to="/settings"  onClick={handleNavClick}>Settings</Link>
+              <div className="sna-mobile-divider" />
+              <button className="sna-btn-ghost" style={{ textAlign:'left', color:'#ef4444' }} onClick={handleLogout}>
+                Sign out
+              </button>
+            </>
+          ) : (
+            <div className="sna-mobile-auth">
+              <Link to="/login"    className="sna-btn-ghost"   onClick={handleNavClick}>Sign In</Link>
+              <Link to="/register" className="sna-btn-primary" onClick={handleNavClick}>Get Started</Link>
+            </div>
+          )}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -13,12 +13,12 @@ import Register from '../pages/Register';
 import ForgotPasswordPage from '../pages/auth/ForgotPasswordPage';
 
 // Main pages — lazy-loaded for code splitting
-const Home = lazy(() => import('../pages/Home'));
-const Explore = lazy(() => import('../pages/Explore'));
+const Home            = lazy(() => import('../pages/Home'));
+const Explore         = lazy(() => import('../pages/Explore'));
 const CampaignDetails = lazy(() => import('../pages/CampaignDetails'));
-const CreateCampaign = lazy(() => import('../pages/CreateCampaign'));
-const Dashboard = lazy(() => import('../pages/Dashboard'));
-const Admin = lazy(() => import('../pages/Admin'));
+const CreateCampaign  = lazy(() => import('../pages/CreateCampaign'));
+const Dashboard       = lazy(() => import('../pages/Dashboard'));
+const Admin           = lazy(() => import('../pages/Admin'));
 
 const SuspenseFallback = () => (
   <div className="flex min-h-screen items-center justify-center">
@@ -32,18 +32,28 @@ const AppRouter = () => {
       <GlobalLoadingWrapper>
         <Suspense fallback={<SuspenseFallback />}>
           <Routes>
-            <Route path="register" element={<Register />} />
-            <Route path="login" element={<Login />} />
-            <Route path="forgot-password" element={<ForgotPasswordPage />} />
-            <Route path="admin" element={<Admin />} />
-            <Route path="dashboard" element={<Dashboard />} />
-            <Route path="*" element={<NotFound />} />
-            <Route path="/" element={<MainLayout />}>
-              <Route index element={<Home />} />
-              <Route path="explore" element={<Explore />} />
-              <Route path="campaign/:id" element={<CampaignDetails />} />
-              <Route path="create" element={<CreateCampaign />} />
-              <Route path="test-error" element={<ErrorTest />} />
+            {/* Every route lives inside MainLayout — Navbar + Footer always present */}
+            <Route element={<MainLayout />}>
+
+              {/* Auth & utility pages */}
+              <Route path="register"        element={<Register />} />
+              <Route path="login"           element={<Login />} />
+              <Route path="forgot-password" element={<ForgotPasswordPage />} />
+              <Route path="admin"           element={<Admin />} />
+              <Route path="dashboard"       element={<Dashboard />} />
+
+              {/* Main public pages */}
+              <Route path="/">
+                <Route index                    element={<Home />} />
+                <Route path="explore"           element={<Explore />} />
+                <Route path="campaign/:id"      element={<CampaignDetails />} />
+                <Route path="create"            element={<CreateCampaign />} />
+                <Route path="test-error"        element={<ErrorTest />} />
+              </Route>
+
+              {/* 404 — also gets Navbar + Footer */}
+              <Route path="*" element={<NotFound />} />
+
             </Route>
           </Routes>
         </Suspense>


### PR DESCRIPTION
Implements the persistent app layout with a sticky Navbar and Footer across all public routes.

## Changes
- \`Navbar.jsx\` — sticky, responsive navbar with logo, nav links, auth buttons (Sign In / Get Started), and avatar dropdown menu when logged in. Collapses to hamburger on mobile.
- \`Footer.jsx\` — four-column footer with Platform, Legal, and Connect (Twitter, Discord, GitHub) sections.
- \`MainLayout.jsx\` — wraps all pages with Navbar + Footer using \`<Outlet />\`. Hosts the \`<Toaster />\` notification system.
- \`AppRouter.jsx\` — all routes (public, auth, dashboard, admin, 404) moved under a single \`<Route element={<MainLayout />}>\`.

## Acceptance Criteria
- [x] Navbar shows Sign In / Get Started when logged out; avatar dropdown when logged in
- [x] Footer present on all public pages
- [x] Layout is fully responsive with hamburger menu on mobile
- [x] Navbar is sticky (stays on scroll)