### PR TITLE
feat: fetch and display current user profile on dashboard

### DIFF
--- a/src/components/dashboard/UserProfileCard.jsx
+++ b/src/components/dashboard/UserProfileCard.jsx
@@ -1,0 +1,73 @@
+import { User, Mail, Shield, Wallet } from 'lucide-react';
+import { useAppSelector } from '../../store/hooks';
+import { selectCurrentUser, selectAuthLoading } from '../../features/auth/authSelectors';
+
+const KYC_BADGE = {
+  verified: { label: 'Verified', className: 'bg-emerald-100 text-emerald-700' },
+  pending:  { label: 'Pending',  className: 'bg-amber-100 text-amber-700' },
+  rejected: { label: 'Rejected', className: 'bg-red-100 text-red-700' },
+};
+
+function truncateAddress(addr) {
+  if (addr.length <= 16) return addr;
+  return `${addr.slice(0, 8)}…${addr.slice(-6)}`;
+}
+
+export default function UserProfileCard() {
+  const user = useAppSelector(selectCurrentUser);
+  const loading = useAppSelector(selectAuthLoading);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 animate-pulse">
+        <div className="h-5 bg-slate-200 rounded w-1/3 mb-5" />
+        <div className="space-y-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <div className="w-4 h-4 bg-slate-200 rounded flex-shrink-0" />
+              <div className="h-4 bg-slate-200 rounded w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const badge = KYC_BADGE[user?.kycStatus] ?? { label: 'Unverified', className: 'bg-slate-100 text-slate-500' };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+      <h2 className="text-lg font-semibold text-slate-800 mb-4">Profile</h2>
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <User className="w-4 h-4 text-slate-400 flex-shrink-0" />
+          <span className="text-sm text-slate-700 truncate">{user?.name || '—'}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Mail className="w-4 h-4 text-slate-400 flex-shrink-0" />
+          <span className="text-sm text-slate-700 truncate">{user?.email || '—'}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Shield className="w-4 h-4 text-slate-400 flex-shrink-0" />
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.className}`}>
+            KYC: {badge.label}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Wallet className="w-4 h-4 text-slate-400 flex-shrink-0" />
+          {user?.walletAddress
+            ? (
+              <span
+                className="text-sm font-mono text-slate-700 truncate"
+                title={user.walletAddress}
+              >
+                {truncateAddress(user.walletAddress)}
+              </span>
+            )
+            : <span className="text-sm text-slate-400 italic">No wallet connected</span>
+          }
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { registerUser, loginUser, logoutUser, verifyEmail, resendEmailVerification, forgotPassword } from './authThunks';
+import { registerUser, loginUser, logoutUser, verifyEmail, resendEmailVerification, forgotPassword, fetchCurrentUser } from './authThunks';
 
 const initialState = {
     user: null,
@@ -114,6 +114,19 @@ const authSlice = createSlice({
                 state.isLoading = false;
             })
             .addCase(forgotPassword.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            })
+            .addCase(fetchCurrentUser.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchCurrentUser.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.user = action.payload.user ?? action.payload;
+                state.error = null;
+            })
+            .addCase(fetchCurrentUser.rejected, (state, action) => {
                 state.isLoading = false;
                 state.error = action.payload;
             });

--- a/src/features/auth/authThunks.js
+++ b/src/features/auth/authThunks.js
@@ -91,6 +91,18 @@ export const forgotPassword = createAsyncThunk(
     }
 );
 
+export const fetchCurrentUser = createAsyncThunk(
+    'auth/fetchCurrentUser',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await api.get('/users/me');
+            return response.data;
+        } catch (err) {
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
 export const resetPassword = createAsyncThunk(
     'auth/resetPassword',
     async ({ token, password }, { rejectWithValue }) => {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,15 +1,50 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertCircle } from 'lucide-react';
 import DonationStatsWidget from '../components/dashboard/DonationStatsWidget';
+import UserProfileCard from '../components/dashboard/UserProfileCard';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { fetchCurrentUser } from '../features/auth/authThunks';
+import { selectCurrentUser } from '../features/auth/authSelectors';
 
 const Dashboard = () => {
+  const dispatch = useAppDispatch();
+  const user = useAppSelector(selectCurrentUser);
+
+  useEffect(() => {
+    dispatch(fetchCurrentUser());
+  }, [dispatch]);
+
   return (
     <div className="max-w-7xl mx-auto p-6 space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-slate-900">Dashboard</h1>
         <p className="text-slate-500 mt-1">Manage your account, donations, and projects.</p>
       </div>
-      
-      <DonationStatsWidget />
+
+      {user && !user.walletAddress && (
+        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 text-amber-800 rounded-lg px-4 py-3">
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm font-medium">
+            Complete your profile — add a wallet address to start receiving donations.
+          </span>
+          <Link
+            to="/profile"
+            className="ml-auto text-sm font-semibold text-amber-900 underline underline-offset-2 hover:text-amber-700 flex-shrink-0"
+          >
+            Go to Profile
+          </Link>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="lg:col-span-1">
+          <UserProfileCard />
+        </div>
+        <div className="lg:col-span-3">
+          <DonationStatsWidget />
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Add `fetchCurrentUser` thunk that calls `GET /api/users/me` and updates `auth.user` in the Redux store
- Add `UserProfileCard` component displaying name, email, KYC status badge, and wallet address in the dashboard
- Dispatch `fetchCurrentUser` on dashboard mount via `useEffect`
- Show a "Complete your profile" banner with a link to `/profile` when `walletAddress` is not set

## Changes

- `src/features/auth/authThunks.js` — new `fetchCurrentUser` async thunk
- `src/features/auth/authSlice.js` — `extraReducers` cases for `fetchCurrentUser` (pending/fulfilled/rejected)
- `src/components/dashboard/UserProfileCard.jsx` — new component with skeleton loading state
- `src/pages/Dashboard.jsx` — dispatches thunk on mount, renders profile card and conditional banner

Closes #66