### PR TITLE
feat: add dashboard Redux slice with async thunks and selectors

### DIFF
--- a/src/features/dashboard/dashboardSelectors.js
+++ b/src/features/dashboard/dashboardSelectors.js
@@ -1,3 +1,5 @@
 export const selectDashboardStats = (state) => state.dashboard.stats;
-export const selectDashboardLoading = (state) => state.dashboard.loading;
+export const selectRecentDonations = (state) => state.dashboard.recentDonations;
+export const selectRecentCampaigns = (state) => state.dashboard.recentCampaigns;
+export const selectDashboardLoading = (state) => state.dashboard.isLoading;
 export const selectDashboardError = (state) => state.dashboard.error;

--- a/src/features/dashboard/dashboardSlice.js
+++ b/src/features/dashboard/dashboardSlice.js
@@ -1,8 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit';
+import {
+    fetchDashboardStats,
+    fetchRecentDonations,
+    fetchRecentCampaigns,
+} from './dashboardThunks';
 
 const initialState = {
-    stats: {},
-    loading: false,
+    stats: null,
+    recentDonations: [],
+    recentCampaigns: [],
+    isLoading: false,
     error: null,
 };
 
@@ -10,9 +17,51 @@ const dashboardSlice = createSlice({
     name: 'dashboard',
     initialState,
     reducers: {
-        // Reducer placeholders
+        clearDashboard: () => initialState,
+    },
+    extraReducers: (builder) => {
+        builder
+            // fetchDashboardStats
+            .addCase(fetchDashboardStats.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchDashboardStats.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.stats = action.payload;
+            })
+            .addCase(fetchDashboardStats.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            })
+            // fetchRecentDonations
+            .addCase(fetchRecentDonations.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchRecentDonations.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.recentDonations = action.payload;
+            })
+            .addCase(fetchRecentDonations.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            })
+            // fetchRecentCampaigns
+            .addCase(fetchRecentCampaigns.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchRecentCampaigns.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.recentCampaigns = action.payload;
+            })
+            .addCase(fetchRecentCampaigns.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            });
     },
 });
 
-
+export const { clearDashboard } = dashboardSlice.actions;
 export default dashboardSlice.reducer;

--- a/src/features/dashboard/dashboardThunks.js
+++ b/src/features/dashboard/dashboardThunks.js
@@ -1,14 +1,42 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { toastSuccess, toastError } from '../../utils/toast';
+import api from '../../services/api';
+import { toastError } from '../../utils/toast';
 
 export const fetchDashboardStats = createAsyncThunk(
     'dashboard/fetchStats',
     async (_, { rejectWithValue }) => {
         try {
-            toastSuccess('Dashboard stats loaded');
-        } catch (error) {
-            toastError(error);
-            return rejectWithValue(error.message);
+            const response = await api.get('/dashboard/stats');
+            return response.data;
+        } catch (err) {
+            toastError(err);
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+export const fetchRecentDonations = createAsyncThunk(
+    'dashboard/fetchRecentDonations',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await api.get('/dashboard/recent-donations');
+            return response.data;
+        } catch (err) {
+            toastError(err);
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+export const fetchRecentCampaigns = createAsyncThunk(
+    'dashboard/fetchRecentCampaigns',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await api.get('/dashboard/recent-campaigns');
+            return response.data;
+        } catch (err) {
+            toastError(err);
+            return rejectWithValue(err.response?.data || err.message);
         }
     }
 );


### PR DESCRIPTION
closes #63

## Description
  Adds the Redux slice for dashboard-level data, following the existing
  feature conventions (split slice / thunks / selectors, shared `api`
  service, `toast` utils).

  ## Changes
  - **dashboardSlice.js** — state shape `{ stats, recentDonations, recentCampaigns, isLoading, error }`; `extraReducers`
  handle pending/fulfilled/rejected for all thunks. Adds a `clearDashboard` reset action.
  - **dashboardThunks.js** — async thunks: `fetchDashboardStats`, `fetchRecentDonations`, `fetchRecentCampaigns` (GET
  `/dashboard/stats`, `/recent-donations`, `/recent-campaigns`).
  - **dashboardSelectors.js** — one selector per state field.

  ## Acceptance criteria
  - [x] Thunks fetch data via the shared API client
  - [x] `isLoading` and `error` update across pending/fulfilled/rejected
  - [x] Selectors exported for each state field
  - [x] ESLint passes

  ## Notes
  - Endpoint paths are assumed; adjust in `dashboardThunks.js` once the API contract is confirmed.
  - Slice was already registered in `rootReducer.js`; no store wiring needed.