### PR TITLE
feat(dashboard): add reusable loading skeleton components

### DIFF
--- a/src/components/common/GlobalLoadingWrapper.jsx
+++ b/src/components/common/GlobalLoadingWrapper.jsx
@@ -1,14 +1,25 @@
+import { useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Spinner from './Spinner';
 
-const selectIsAnyLoading = (state) =>
-  state.auth.isLoading ||
-  state.campaigns.loading ||
-  state.donations.loading ||
-  state.dashboard.loading;
+const isDashboardRoute = (pathname) => pathname.startsWith('/dashboard');
 
 const GlobalLoadingWrapper = ({ children }) => {
-  const isReduxLoading = useSelector(selectIsAnyLoading);
+  const { pathname } = useLocation();
+  const onDashboard = isDashboardRoute(pathname);
+
+  const isReduxLoading = useSelector((state) => {
+    if (onDashboard) {
+      return state.campaigns.loading || state.donations.loading;
+    }
+
+    return (
+      state.auth.isLoading ||
+      state.campaigns.loading ||
+      state.donations.loading ||
+      state.dashboard.isLoading
+    );
+  });
 
   return (
     <>

--- a/src/components/common/GlobalLoadingWrapper.test.jsx
+++ b/src/components/common/GlobalLoadingWrapper.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import GlobalLoadingWrapper from './GlobalLoadingWrapper';
+
+const createStore = (overrides = {}) => configureStore({
+  reducer: {
+    auth: () => ({ isLoading: false, ...overrides.auth }),
+    campaigns: () => ({ loading: false, ...overrides.campaigns }),
+    donations: () => ({ loading: false, ...overrides.donations }),
+    dashboard: () => ({ isLoading: false, ...overrides.dashboard }),
+  },
+});
+
+const renderAt = (path, store) => render(
+  <Provider store={store}>
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={<GlobalLoadingWrapper><div>Page</div></GlobalLoadingWrapper>} />
+      </Routes>
+    </MemoryRouter>
+  </Provider>,
+);
+
+describe('GlobalLoadingWrapper', () => {
+  it('does not show overlay for auth loading on dashboard routes', () => {
+    const store = createStore({ auth: { isLoading: true } });
+    renderAt('/dashboard', store);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('shows overlay for auth loading outside dashboard routes', () => {
+    const store = createStore({ auth: { isLoading: true } });
+    renderAt('/campaigns', store);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/Skeleton.jsx
+++ b/src/components/common/Skeleton.jsx
@@ -1,0 +1,29 @@
+const borderRadiusMap = {
+  md: '0.375rem',
+  lg: '0.5rem',
+  full: '9999px',
+};
+
+const Skeleton = ({
+  width = '100%',
+  height = '1rem',
+  rounded = 'md',
+  className = '',
+}) => {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse shrink-0 ${className}`}
+      style={{
+        display: 'block',
+        width,
+        height,
+        minHeight: height,
+        borderRadius: borderRadiusMap[rounded] ?? borderRadiusMap.md,
+        backgroundColor: '#cbd5e1',
+      }}
+    />
+  );
+};
+
+export default Skeleton;

--- a/src/components/common/Skeleton.test.jsx
+++ b/src/components/common/Skeleton.test.jsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Skeleton from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders with explicit dimensions and background', () => {
+    const { container } = render(<Skeleton width="120px" height="16px" />);
+    const bar = container.firstChild;
+
+    expect(bar).toHaveStyle({
+      width: '120px',
+      height: '16px',
+      backgroundColor: 'rgb(203, 213, 225)',
+      display: 'block',
+    });
+  });
+});

--- a/src/components/dashboard/CampaignStatsWidget.jsx
+++ b/src/components/dashboard/CampaignStatsWidget.jsx
@@ -7,6 +7,7 @@ import {
   Clock,
   ArrowRight
 } from 'lucide-react';
+import { StatCardsGridSkeleton } from './dashboardSkeletonParts';
 
 /**
  * AnimatedCounter component to animate number totals
@@ -119,21 +120,11 @@ const CampaignStatsWidget = () => {
       </div>
       
       <div className="p-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {loading ? (
-            // Skeleton Loader
-            Array.from({ length: 4 }).map((_, index) => (
-              <div key={index} className="flex items-center p-4 bg-slate-50 rounded-lg border border-slate-100 animate-pulse" data-testid="skeleton">
-                <div className="w-12 h-12 bg-slate-200 rounded-full flex-shrink-0 mr-4"></div>
-                <div className="flex-1">
-                  <div className="h-4 bg-slate-200 rounded w-2/3 mb-2"></div>
-                  <div className="h-6 bg-slate-200 rounded w-1/2"></div>
-                </div>
-              </div>
-            ))
-          ) : (
-            // Actual Stats
-            statItems.map((item, index) => (
+        {loading ? (
+          <StatCardsGridSkeleton />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {statItems.map((item, index) => (
               <div 
                 key={index} 
                 className="flex items-center p-4 bg-slate-50 hover:bg-slate-100 transition-colors rounded-lg border border-slate-100 group cursor-default"
@@ -148,9 +139,9 @@ const CampaignStatsWidget = () => {
                   </p>
                 </div>
               </div>
-            ))
-          )}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/CampaignStatsWidget.test.jsx
+++ b/src/components/dashboard/CampaignStatsWidget.test.jsx
@@ -23,9 +23,8 @@ describe('CampaignStatsWidget', () => {
       </MemoryRouter>
     );
 
-    // Wait for data to load (simulated with 1200ms in component)
     await waitFor(() => {
-      expect(screen.getByText('Campaign Overview')).toBeInTheDocument();
+      expect(screen.getByText('Total Campaigns')).toBeInTheDocument();
     }, { timeout: 3000 });
 
     expect(screen.getByText('Total Campaigns')).toBeInTheDocument();

--- a/src/components/dashboard/DashboardSkeleton.jsx
+++ b/src/components/dashboard/DashboardSkeleton.jsx
@@ -1,0 +1,22 @@
+import {
+  ProfileSkeleton,
+  StatsWidgetSkeleton,
+} from './dashboardSkeletonParts';
+
+const DashboardSkeleton = () => {
+  return (
+    <div role="status" aria-label="Loading dashboard" className="w-full">
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="lg:col-span-1">
+          <ProfileSkeleton />
+        </div>
+
+        <div className="lg:col-span-3 space-y-6">
+          <StatsWidgetSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardSkeleton;

--- a/src/components/dashboard/DashboardSkeleton.test.jsx
+++ b/src/components/dashboard/DashboardSkeleton.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DashboardSkeleton from './DashboardSkeleton';
+
+describe('DashboardSkeleton', () => {
+  it('renders profile and stat card skeleton placeholders', () => {
+    render(<DashboardSkeleton />);
+
+    const skeletons = screen.getAllByTestId('skeleton');
+    expect(skeletons).toHaveLength(4);
+  });
+});

--- a/src/components/dashboard/DonationStatsWidget.jsx
+++ b/src/components/dashboard/DonationStatsWidget.jsx
@@ -7,6 +7,7 @@ import {
   Activity,
   ArrowRight
 } from 'lucide-react';
+import { StatCardsGridSkeleton } from './dashboardSkeletonParts';
 
 const DonationStatsWidget = () => {
   const [loading, setLoading] = useState(true);
@@ -68,21 +69,11 @@ const DonationStatsWidget = () => {
       </div>
       
       <div className="p-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {loading ? (
-            // Skeleton Loader
-            Array.from({ length: 4 }).map((_, index) => (
-              <div key={index} className="flex items-center p-4 bg-slate-50 rounded-lg border border-slate-100 animate-pulse">
-                <div className="w-12 h-12 bg-slate-200 rounded-full flex-shrink-0 mr-4"></div>
-                <div className="flex-1">
-                  <div className="h-4 bg-slate-200 rounded w-2/3 mb-2"></div>
-                  <div className="h-6 bg-slate-200 rounded w-1/2"></div>
-                </div>
-              </div>
-            ))
-          ) : (
-            // Actual Stats
-            statItems.map((item, index) => (
+        {loading ? (
+          <StatCardsGridSkeleton />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {statItems.map((item, index) => (
               <div 
                 key={index} 
                 className="flex items-center p-4 bg-slate-50 hover:bg-slate-100 transition-colors rounded-lg border border-slate-100 group cursor-default"
@@ -95,9 +86,9 @@ const DonationStatsWidget = () => {
                   <p className="text-xl font-bold text-slate-800">{item.value}</p>
                 </div>
               </div>
-            ))
-          )}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/RecentDonations.jsx
+++ b/src/components/dashboard/RecentDonations.jsx
@@ -7,6 +7,7 @@ import {
   selectRecentDonations,
   selectDashboardLoading,
 } from '../../features/dashboard/dashboardSelectors';
+import { TableRowSkeleton } from './dashboardSkeletonParts';
 
 // ─── Status badge config ──────────────────────────────────────────────────────
 const STATUS_BADGE = {
@@ -25,19 +26,6 @@ function StatusBadge({ status }) {
     <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${cfg.className}`}>
       {cfg.label}
     </span>
-  );
-}
-
-// ─── Skeleton row ─────────────────────────────────────────────────────────────
-function SkeletonRow() {
-  return (
-    <tr className="animate-pulse">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <td key={i} className="px-4 py-3">
-          <div className="h-4 bg-slate-200 rounded w-3/4" />
-        </td>
-      ))}
-    </tr>
   );
 }
 
@@ -83,7 +71,7 @@ export default function RecentDonations() {
           <tbody className="divide-y divide-slate-100">
             {loading ? (
               // Skeleton rows while fetching
-              Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+              Array.from({ length: 5 }).map((_, i) => <TableRowSkeleton key={i} />)
             ) : recent.length === 0 ? (
               // Empty state
               <tr>

--- a/src/components/dashboard/UserProfileCard.jsx
+++ b/src/components/dashboard/UserProfileCard.jsx
@@ -1,6 +1,7 @@
 import { User, Mail, Shield, Wallet } from 'lucide-react';
 import { useAppSelector } from '../../store/hooks';
 import { selectCurrentUser, selectAuthLoading } from '../../features/auth/authSelectors';
+import { ProfileSkeleton } from './dashboardSkeletonParts';
 
 const KYC_BADGE = {
   verified: { label: 'Verified', className: 'bg-emerald-100 text-emerald-700' },
@@ -18,19 +19,7 @@ export default function UserProfileCard() {
   const loading = useAppSelector(selectAuthLoading);
 
   if (loading) {
-    return (
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 animate-pulse">
-        <div className="h-5 bg-slate-200 rounded w-1/3 mb-5" />
-        <div className="space-y-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-3">
-              <div className="w-4 h-4 bg-slate-200 rounded flex-shrink-0" />
-              <div className="h-4 bg-slate-200 rounded w-3/4" />
-            </div>
-          ))}
-        </div>
-      </div>
-    );
+    return <ProfileSkeleton />;
   }
 
   const badge = KYC_BADGE[user?.kycStatus] ?? { label: 'Unverified', className: 'bg-slate-100 text-slate-500' };

--- a/src/components/dashboard/dashboardSkeletonParts.jsx
+++ b/src/components/dashboard/dashboardSkeletonParts.jsx
@@ -1,0 +1,68 @@
+import Skeleton from '../common/Skeleton';
+
+const skeletonBlock = {
+  backgroundColor: '#cbd5e1',
+};
+
+export const ProfileSkeleton = () => (
+  <div className="min-h-[220px] bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <Skeleton width="33%" height="1.25rem" className="mb-5" />
+    <div className="space-y-4 min-h-[140px]">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 min-h-[1.25rem]">
+          <div
+            className="shrink-0 animate-pulse rounded"
+            style={{ ...skeletonBlock, width: '1rem', height: '1rem' }}
+          />
+          <Skeleton width="75%" height="1rem" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const StatCardSkeleton = () => (
+  <div
+    className="flex items-center min-h-[88px] p-4 bg-slate-100 rounded-lg border border-slate-200"
+    data-testid="skeleton"
+  >
+    <div
+      className="shrink-0 mr-4 animate-pulse"
+      style={{ ...skeletonBlock, width: '3rem', height: '3rem', borderRadius: '9999px' }}
+    />
+    <div className="flex-1 min-w-0 space-y-2">
+      <Skeleton width="66%" height="1rem" />
+      <Skeleton width="50%" height="1.5rem" />
+    </div>
+  </div>
+);
+
+export const StatCardsGridSkeleton = ({ count = 4 }) => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 min-h-[88px]">
+    {Array.from({ length: count }).map((_, i) => (
+      <StatCardSkeleton key={i} />
+    ))}
+  </div>
+);
+
+export const StatsWidgetSkeleton = ({ statCount = 4 }) => (
+  <div className="min-h-[280px] bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+    <div className="flex items-center justify-between min-h-[72px] p-6 border-b border-slate-100 bg-white">
+      <Skeleton width="11rem" height="1.25rem" />
+      <Skeleton width="5rem" height="1rem" />
+    </div>
+    <div className="p-6 bg-white min-h-[200px]">
+      <StatCardsGridSkeleton count={statCount} />
+    </div>
+  </div>
+);
+
+export const TableRowSkeleton = ({ columns = 5 }) => (
+  <tr className="min-h-[48px]">
+    {Array.from({ length: columns }).map((_, i) => (
+      <td key={i} className="px-4 py-3">
+        <Skeleton width="75%" height="1rem" />
+      </td>
+    ))}
+  </tr>
+);

--- a/src/pages/dashboard/DashboardPage.jsx
+++ b/src/pages/dashboard/DashboardPage.jsx
@@ -2,14 +2,16 @@ import { useEffect } from 'react';
 import { AlertCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import DonationStatsWidget from '../../components/dashboard/DonationStatsWidget';
+import DashboardSkeleton from '../../components/dashboard/DashboardSkeleton';
 import UserProfileCard from '../../components/dashboard/UserProfileCard';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { fetchCurrentUser } from '../../features/auth/authThunks';
-import { selectCurrentUser } from '../../features/auth/authSelectors';
+import { selectAuthLoading, selectCurrentUser } from '../../features/auth/authSelectors';
 
 export default function DashboardPage() {
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectCurrentUser);
+  const loading = useAppSelector(selectAuthLoading);
 
   useEffect(() => {
     dispatch(fetchCurrentUser());
@@ -37,14 +39,18 @@ export default function DashboardPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        <div className="lg:col-span-1">
-          <UserProfileCard />
+      {loading ? (
+        <DashboardSkeleton />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          <div className="lg:col-span-1">
+            <UserProfileCard />
+          </div>
+          <div className="lg:col-span-3">
+            <DonationStatsWidget />
+          </div>
         </div>
-        <div className="lg:col-span-3">
-          <DonationStatsWidget />
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/pages/dashboard/DashboardPage.test.jsx
+++ b/src/pages/dashboard/DashboardPage.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import DashboardPage from './DashboardPage';
+
+const createStore = (authOverrides = {}) => configureStore({
+  reducer: {
+    auth: () => ({
+      isLoading: false,
+      user: null,
+      isAuthenticated: true,
+      ...authOverrides,
+    }),
+  },
+});
+
+describe('DashboardPage', () => {
+  it('renders DashboardSkeleton while auth is loading', () => {
+    render(
+      <Provider store={createStore({ isLoading: true })}>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading dashboard' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('skeleton').length).toBe(4);
+  });
+
+  it('renders dashboard widgets when auth is not loading', () => {
+    render(
+      <Provider store={createStore({ isLoading: false })}>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.queryByRole('status', { name: 'Loading dashboard' })).not.toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #76

Summary
Adds reusable loading skeleton components for the dashboard that match the real layout and eliminate duplicated skeleton code.

Changes
- New Skeleton primitive
- Shared dashboard skeleton parts
- Integrated into DashboardPage
- Refactored widgets to use shared components
- Updated GlobalLoadingWrapper for dashboard routes

Testing
- All tests passing
- Manual verification on /dashboard shows proper pulsing skeletons