### PR TITLE
implement-Basic info form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^5.1.1",
+        "@vitejs/plugin-react": "^5.2.0",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -2179,9 +2179,9 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2196,7 +2196,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.1",
+    "@vitejs/plugin-react": "^5.2.0",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/components/campaigns/steps/BasicInfoStep.jsx
+++ b/src/components/campaigns/steps/BasicInfoStep.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { selectDraftCampaign, updateDraftCampaign } from '../../../../features/campaigns/campaignsSlice';
+
+const CATEGORIES = ['Education', 'Health', 'Environment', 'Disaster Relief', 'Community'];
+
+const schema = yup.object({
+  title: yup.string().required('Title is required').max(100, 'Must be 100 characters or less'),
+  category: yup.string().required('Category is required'),
+  shortDescription: yup.string().required('Short description is required').max(200, 'Must be 200 characters or less'),
+  fullStory: yup.string().required('Full story is required'),
+});
+
+const BasicInfoStep = ({ validationRef }) => {
+  const dispatch = useDispatch();
+  const draft = useSelector(selectDraftCampaign);
+
+  const { register, handleSubmit, watch, trigger, formState, setValue } = useForm({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      title: draft.title || '',
+      category: draft.category || '',
+      shortDescription: draft.description || '',
+      fullStory: draft.fullStory || draft.description || '',
+    },
+    mode: 'onChange',
+  });
+
+  // Keep local form values in sync if draft changes externally
+  useEffect(() => {
+    setValue('title', draft.title || '');
+    setValue('category', draft.category || '');
+    setValue('shortDescription', draft.description || '');
+    setValue('fullStory', draft.fullStory || draft.description || '');
+  }, [draft, setValue]);
+
+  // Debounced autosave to Redux when form values change
+  const timeoutRef = useRef(null);
+  const watched = watch();
+  useEffect(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      dispatch(
+        updateDraftCampaign({
+          title: watched.title || '',
+          category: watched.category || '',
+          description: watched.shortDescription || '',
+          fullStory: watched.fullStory || '',
+        })
+      );
+    }, 550);
+    return () => clearTimeout(timeoutRef.current);
+  }, [watched, dispatch]);
+
+  // Expose a validate function to parent via validationRef
+  useEffect(() => {
+    if (!validationRef) return;
+    validationRef.current = {
+      validate: async () => {
+        const valid = await trigger();
+        if (valid) {
+          // ensure final save before proceeding
+          const values = await handleSubmit((vals) => vals)();
+          dispatch(
+            updateDraftCampaign({
+              title: values.title,
+              category: values.category,
+              description: values.shortDescription,
+              fullStory: values.fullStory,
+            })
+          );
+        }
+        return valid;
+      },
+    };
+    return () => {
+      if (validationRef.current && validationRef.current.validate) {
+        validationRef.current = null;
+      }
+    };
+  }, [validationRef, trigger, handleSubmit, dispatch]);
+
+  const title = watch('title') || '';
+  const shortDescription = watch('shortDescription') || '';
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="title" className="mb-1 block text-sm font-medium text-slate-700">
+          Campaign Title
+        </label>
+        <input
+          id="title"
+          type="text"
+          maxLength={100}
+          {...register('title')}
+          placeholder="e.g. Clean Water Initiative"
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
+        />
+        <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
+          <span>{formState.errors.title ? formState.errors.title.message : ''}</span>
+          <span>{title.length}/100</span>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="category" className="mb-1 block text-sm font-medium text-slate-700">
+          Category
+        </label>
+        <select
+          id="category"
+          {...register('category')}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
+        >
+          <option value="">Select a category</option>
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+        <div className="mt-1 text-xs text-slate-500">{formState.errors.category?.message || ''}</div>
+      </div>
+
+      <div>
+        <label htmlFor="shortDescription" className="mb-1 block text-sm font-medium text-slate-700">
+          Short Description
+        </label>
+        <textarea
+          id="shortDescription"
+          rows={3}
+          maxLength={200}
+          {...register('shortDescription')}
+          placeholder="A short summary for listings..."
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
+        />
+        <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
+          <span>{formState.errors.shortDescription ? formState.errors.shortDescription.message : ''}</span>
+          <span>{shortDescription.length}/200</span>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="fullStory" className="mb-1 block text-sm font-medium text-slate-700">
+          Full Story
+        </label>
+        <textarea
+          id="fullStory"
+          rows={8}
+          {...register('fullStory')}
+          placeholder="Write the full story for your campaign. You can include formatting in a later iteration."
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
+        />
+        <div className="mt-1 text-xs text-slate-500">{formState.errors.fullStory?.message || ''}</div>
+      </div>
+    </div>
+  );
+};
+
+export default BasicInfoStep;

--- a/src/components/campaigns/steps/BasicInfoStep.jsx
+++ b/src/components/campaigns/steps/BasicInfoStep.jsx
@@ -1,40 +1,56 @@
-import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
-import { selectDraftCampaign, updateDraftCampaign } from '../../../../features/campaigns/campaignsSlice';
+import { useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import {
+  selectDraftCampaign,
+  updateDraftCampaign,
+} from "../../../../features/campaigns/campaignsSlice";
 
-const CATEGORIES = ['Education', 'Health', 'Environment', 'Disaster Relief', 'Community'];
+const CATEGORIES = [
+  "Education",
+  "Health",
+  "Environment",
+  "Disaster Relief",
+  "Community",
+];
 
 const schema = yup.object({
-  title: yup.string().required('Title is required').max(100, 'Must be 100 characters or less'),
-  category: yup.string().required('Category is required'),
-  shortDescription: yup.string().required('Short description is required').max(200, 'Must be 200 characters or less'),
-  fullStory: yup.string().required('Full story is required'),
+  title: yup
+    .string()
+    .required("Title is required")
+    .max(100, "Must be 100 characters or less"),
+  category: yup.string().required("Category is required"),
+  shortDescription: yup
+    .string()
+    .required("Short description is required")
+    .max(200, "Must be 200 characters or less"),
+  fullStory: yup.string().required("Full story is required"),
 });
 
 const BasicInfoStep = ({ validationRef }) => {
   const dispatch = useDispatch();
   const draft = useSelector(selectDraftCampaign);
 
-  const { register, handleSubmit, watch, trigger, formState, setValue } = useForm({
-    resolver: yupResolver(schema),
-    defaultValues: {
-      title: draft.title || '',
-      category: draft.category || '',
-      shortDescription: draft.description || '',
-      fullStory: draft.fullStory || draft.description || '',
-    },
-    mode: 'onChange',
-  });
+  const { register, handleSubmit, watch, trigger, formState, setValue } =
+    useForm({
+      resolver: yupResolver(schema),
+      defaultValues: {
+        title: draft.title || "",
+        category: draft.category || "",
+        shortDescription: draft.description || "",
+        fullStory: draft.fullStory || draft.description || "",
+      },
+      mode: "onChange",
+    });
 
   // Keep local form values in sync if draft changes externally
   useEffect(() => {
-    setValue('title', draft.title || '');
-    setValue('category', draft.category || '');
-    setValue('shortDescription', draft.description || '');
-    setValue('fullStory', draft.fullStory || draft.description || '');
+    setValue("title", draft.title || "");
+    setValue("category", draft.category || "");
+    setValue("shortDescription", draft.description || "");
+    setValue("fullStory", draft.fullStory || draft.description || "");
   }, [draft, setValue]);
 
   // Debounced autosave to Redux when form values change
@@ -45,11 +61,11 @@ const BasicInfoStep = ({ validationRef }) => {
     timeoutRef.current = setTimeout(() => {
       dispatch(
         updateDraftCampaign({
-          title: watched.title || '',
-          category: watched.category || '',
-          description: watched.shortDescription || '',
-          fullStory: watched.fullStory || '',
-        })
+          title: watched.title || "",
+          category: watched.category || "",
+          description: watched.shortDescription || "",
+          fullStory: watched.fullStory || "",
+        }),
       );
     }, 550);
     return () => clearTimeout(timeoutRef.current);
@@ -70,7 +86,7 @@ const BasicInfoStep = ({ validationRef }) => {
               category: values.category,
               description: values.shortDescription,
               fullStory: values.fullStory,
-            })
+            }),
           );
         }
         return valid;
@@ -83,36 +99,44 @@ const BasicInfoStep = ({ validationRef }) => {
     };
   }, [validationRef, trigger, handleSubmit, dispatch]);
 
-  const title = watch('title') || '';
-  const shortDescription = watch('shortDescription') || '';
+  const title = watch("title") || "";
+  const shortDescription = watch("shortDescription") || "";
 
   return (
     <div className="space-y-4">
       <div>
-        <label htmlFor="title" className="mb-1 block text-sm font-medium text-slate-700">
+        <label
+          htmlFor="title"
+          className="mb-1 block text-sm font-medium text-slate-700"
+        >
           Campaign Title
         </label>
         <input
           id="title"
           type="text"
           maxLength={100}
-          {...register('title')}
+          {...register("title")}
           placeholder="e.g. Clean Water Initiative"
           className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
         />
         <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
-          <span>{formState.errors.title ? formState.errors.title.message : ''}</span>
+          <span>
+            {formState.errors.title ? formState.errors.title.message : ""}
+          </span>
           <span>{title.length}/100</span>
         </div>
       </div>
 
       <div>
-        <label htmlFor="category" className="mb-1 block text-sm font-medium text-slate-700">
+        <label
+          htmlFor="category"
+          className="mb-1 block text-sm font-medium text-slate-700"
+        >
           Category
         </label>
         <select
           id="category"
-          {...register('category')}
+          {...register("category")}
           className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
         >
           <option value="">Select a category</option>
@@ -122,39 +146,53 @@ const BasicInfoStep = ({ validationRef }) => {
             </option>
           ))}
         </select>
-        <div className="mt-1 text-xs text-slate-500">{formState.errors.category?.message || ''}</div>
+        <div className="mt-1 text-xs text-slate-500">
+          {formState.errors.category?.message || ""}
+        </div>
       </div>
 
       <div>
-        <label htmlFor="shortDescription" className="mb-1 block text-sm font-medium text-slate-700">
+        <label
+          htmlFor="shortDescription"
+          className="mb-1 block text-sm font-medium text-slate-700"
+        >
           Short Description
         </label>
         <textarea
           id="shortDescription"
           rows={3}
           maxLength={200}
-          {...register('shortDescription')}
+          {...register("shortDescription")}
           placeholder="A short summary for listings..."
           className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
         />
         <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
-          <span>{formState.errors.shortDescription ? formState.errors.shortDescription.message : ''}</span>
+          <span>
+            {formState.errors.shortDescription
+              ? formState.errors.shortDescription.message
+              : ""}
+          </span>
           <span>{shortDescription.length}/200</span>
         </div>
       </div>
 
       <div>
-        <label htmlFor="fullStory" className="mb-1 block text-sm font-medium text-slate-700">
+        <label
+          htmlFor="fullStory"
+          className="mb-1 block text-sm font-medium text-slate-700"
+        >
           Full Story
         </label>
         <textarea
           id="fullStory"
           rows={8}
-          {...register('fullStory')}
+          {...register("fullStory")}
           placeholder="Write the full story for your campaign. You can include formatting in a later iteration."
           className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-accent focus:ring-accent"
         />
-        <div className="mt-1 text-xs text-slate-500">{formState.errors.fullStory?.message || ''}</div>
+        <div className="mt-1 text-xs text-slate-500">
+          {formState.errors.fullStory?.message || ""}
+        </div>
       </div>
     </div>
   );

--- a/src/components/campaigns/steps/BasicInfoStep.jsx
+++ b/src/components/campaigns/steps/BasicInfoStep.jsx
@@ -6,7 +6,7 @@ import * as yup from "yup";
 import {
   selectDraftCampaign,
   updateDraftCampaign,
-} from "../../../../features/campaigns/campaignsSlice";
+} from "../../../features/campaigns/campaignsSlice";
 
 const CATEGORIES = [
   "Education",
@@ -45,9 +45,10 @@ const BasicInfoStep = ({ validationRef }) => {
       mode: "onChange",
     });
 
-  // Keep local form values in sync if draft changes externally
+  // Keep local form values in sync if draft changes externally (e.g., from Redux store updates)
   useEffect(() => {
     setValue("title", draft.title || "");
+
     setValue("category", draft.category || "");
     setValue("shortDescription", draft.description || "");
     setValue("fullStory", draft.fullStory || draft.description || "");

--- a/src/pages/campaigns/CreateCampaignPage.jsx
+++ b/src/pages/campaigns/CreateCampaignPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useBeforeUnload } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -9,13 +9,13 @@ import {
   selectDraftCampaign,
   selectFormStep,
 } from '../../features/campaigns/campaignsSlice';
-import DetailsStep from './steps/DetailsStep';
+import BasicInfoStep from '../../components/campaigns/steps/BasicInfoStep';
 import FundingStep from './steps/FundingStep';
 import MediaStep from './steps/MediaStep';
 import ReviewStep from './steps/ReviewStep';
 
 const STEP_META = [
-  { id: 'details', title: 'Campaign Details', Component: DetailsStep },
+  { id: 'details', title: 'Campaign Details', Component: BasicInfoStep },
   { id: 'funding', title: 'Funding Goal', Component: FundingStep },
   { id: 'media', title: 'Media', Component: MediaStep },
   { id: 'review', title: 'Review & Submit', Component: ReviewStep },
@@ -48,7 +48,17 @@ const CreateCampaignPage = () => {
   const isLastStep = formStep === CAMPAIGN_STEPS.length - 1;
   const { title, Component } = STEP_META[formStep];
 
-  const handleNext = () => dispatch(nextStep());
+  const validationRef = useRef(null);
+
+  const handleNext = async () => {
+    // If the step exposes a validator, run it and only advance when valid.
+    if (validationRef.current && typeof validationRef.current.validate === 'function') {
+      const ok = await validationRef.current.validate();
+      if (ok) dispatch(nextStep());
+    } else {
+      dispatch(nextStep());
+    }
+  };
   const handleBack = () => dispatch(prevStep());
 
   const handleSubmit = () => {
@@ -99,7 +109,7 @@ const CreateCampaignPage = () => {
         <h2 className="mb-4 text-lg font-semibold text-primary">
           Step {formStep + 1}: {title}
         </h2>
-        <Component />
+        <Component validationRef={validationRef} />
       </div>
 
       <div className="flex items-center justify-between">

--- a/src/pages/campaigns/CreateCampaignPage.jsx
+++ b/src/pages/campaigns/CreateCampaignPage.jsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useRef } from 'react';
-import { useBeforeUnload } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback, useMemo, useRef } from "react";
+import { useBeforeUnload } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import {
   CAMPAIGN_STEPS,
   nextStep,
@@ -8,21 +8,21 @@ import {
   resetCampaignForm,
   selectDraftCampaign,
   selectFormStep,
-} from '../../features/campaigns/campaignsSlice';
-import BasicInfoStep from '../../components/campaigns/steps/BasicInfoStep';
-import FundingStep from './steps/FundingStep';
-import MediaStep from './steps/MediaStep';
-import ReviewStep from './steps/ReviewStep';
+} from "../../features/campaigns/campaignsSlice";
+import BasicInfoStep from "../../components/campaigns/steps/BasicInfoStep";
+import FundingStep from "./steps/FundingStep";
+import MediaStep from "./steps/MediaStep";
+import ReviewStep from "./steps/ReviewStep";
 
 const STEP_META = [
-  { id: 'details', title: 'Campaign Details', Component: BasicInfoStep },
-  { id: 'funding', title: 'Funding Goal', Component: FundingStep },
-  { id: 'media', title: 'Media', Component: MediaStep },
-  { id: 'review', title: 'Review & Submit', Component: ReviewStep },
+  { id: "details", title: "Campaign Details", Component: BasicInfoStep },
+  { id: "funding", title: "Funding Goal", Component: FundingStep },
+  { id: "media", title: "Media", Component: MediaStep },
+  { id: "review", title: "Review & Submit", Component: ReviewStep },
 ];
 
 const hasUnsavedData = (draft) =>
-  Object.values(draft).some((value) => String(value).trim() !== '');
+  Object.values(draft).some((value) => String(value).trim() !== "");
 
 const CreateCampaignPage = () => {
   const dispatch = useDispatch();
@@ -37,11 +37,11 @@ const CreateCampaignPage = () => {
       (event) => {
         if (isDirty) {
           event.preventDefault();
-          event.returnValue = '';
+          event.returnValue = "";
         }
       },
-      [isDirty]
-    )
+      [isDirty],
+    ),
   );
 
   const isFirstStep = formStep === 0;
@@ -52,7 +52,10 @@ const CreateCampaignPage = () => {
 
   const handleNext = async () => {
     // If the step exposes a validator, run it and only advance when valid.
-    if (validationRef.current && typeof validationRef.current.validate === 'function') {
+    if (
+      validationRef.current &&
+      typeof validationRef.current.validate === "function"
+    ) {
       const ok = await validationRef.current.validate();
       if (ok) dispatch(nextStep());
     } else {
@@ -63,7 +66,7 @@ const CreateCampaignPage = () => {
 
   const handleSubmit = () => {
     // Placeholder submit; integrates with campaign service in a later issue.
-    console.log('Submitting campaign draft:', draft);
+    console.log("Submitting campaign draft:", draft);
     dispatch(resetCampaignForm());
   };
 
@@ -83,20 +86,20 @@ const CreateCampaignPage = () => {
             <li key={step.id} className="flex flex-1 items-center gap-2">
               <span
                 className={[
-                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold',
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold",
                   isCurrent
-                    ? 'bg-accent text-white'
+                    ? "bg-accent text-white"
                     : isComplete
-                      ? 'bg-green-500 text-white'
-                      : 'bg-slate-200 text-slate-500',
-                ].join(' ')}
+                      ? "bg-green-500 text-white"
+                      : "bg-slate-200 text-slate-500",
+                ].join(" ")}
               >
-                {isComplete ? '✓' : index + 1}
+                {isComplete ? "✓" : index + 1}
               </span>
               {index < STEP_META.length - 1 && (
                 <span
                   className={`hidden h-0.5 flex-1 rounded sm:block ${
-                    isComplete ? 'bg-green-500' : 'bg-slate-200'
+                    isComplete ? "bg-green-500" : "bg-slate-200"
                   }`}
                 />
               )}


### PR DESCRIPTION
PR Description

This PR introduces a new Basic Info step for the campaign creation flow and integrates it into the multi-step campaign setup.

✨ Changes Made

BasicInfoStep.jsx

Added form fields:
Campaign Title (max 100 chars)
Category (dropdown)
Short Description (max 200 chars)
Full Story (textarea)
Displays live character counters for Title and Short Description
Implements validation using Yup (required fields + length constraints)
Auto-saves form data to draftCampaign in Redux with a 550ms debounce
Exposes a validate() method via validationRef to allow parent-level validation before proceeding

CreateCampaignPage.jsx

Replaced existing first step with BasicInfoStep
Integrated validationRef into step handling
Updated Next button logic:
Runs step validation before advancing
Only proceeds if validation passes
Ensures valid data is saved to Redux draft before moving forward

🧩 Files Changed
BasicInfoStep.jsx
CreateCampaignPage.jsx

closes: #93 